### PR TITLE
Feature: Reworked presence notification

### DIFF
--- a/lib/spcharms/config.py
+++ b/lib/spcharms/config.py
@@ -150,3 +150,13 @@ def set_meta_config(data):
     cached_meta = None
     m()
     reactive.set_state('storpool-helper.config-set')
+
+
+def get_cached_meta_config():
+    """
+    Return only whatever was explicity set using set_meta_config().
+    """
+    data = unitdata.kv().get(kvdata.KEY_META_CONFIG, None)
+    if data is None or data == 'None':
+        return None
+    return data

--- a/lib/spcharms/config.py
+++ b/lib/spcharms/config.py
@@ -30,7 +30,7 @@ class QuasiConfig(object):
         self.override[key] = value
         self.changed_attrs[key] = changed
 
-    def get(self, key, default):
+    def get(self, key, default=None):
         return self.override.get(key, self.config.get(key, default))
 
     def changed(self, key):

--- a/lib/spcharms/kvdata.py
+++ b/lib/spcharms/kvdata.py
@@ -13,5 +13,7 @@ KEY_META_CONFIG = 'storpool-helper.meta-config'
 KEY_LXD_NAME = 'storpool-openstack-integration.lxd-name'
 
 KEY_PRESENCE = 'storpool-service.state'
+KEY_REMOTE_PRESENCE = 'storpool-presence.state'
+KEY_REMOTE_PRESENCE_STR = 'storpool-presence.str'
 
 KEY_SPSTATUS = 'storpool-utils.persistent-status'

--- a/lib/spcharms/kvdata.py
+++ b/lib/spcharms/kvdata.py
@@ -14,6 +14,5 @@ KEY_LXD_NAME = 'storpool-openstack-integration.lxd-name'
 
 KEY_PRESENCE = 'storpool-service.state'
 KEY_REMOTE_PRESENCE = 'storpool-presence.state'
-KEY_REMOTE_PRESENCE_STR = 'storpool-presence.str'
 
 KEY_SPSTATUS = 'storpool-utils.persistent-status'

--- a/lib/spcharms/repo.py
+++ b/lib/spcharms/repo.py
@@ -78,8 +78,7 @@ def pkgs_to_install(requested, policy):
                     None)
 
         req = requested[p]
-        if ver['installed'] is not None and \
-           (req == '*' or req == ver['installed']):
+        if ver['installed'] is not None and req == ver['installed']:
             continue
         elif ver['candidate'] is None:
             return ('the {pkg} package is not available in the repositories, '
@@ -90,6 +89,8 @@ def pkgs_to_install(requested, policy):
                     'in the repositories, we have {cand} instead'
                     .format(req=req, pkg=p, cand=ver['candidate']),
                     None)
+        elif ver['candidate'] == ver['installed']:
+            continue
 
         to_install.append(p)
 

--- a/lib/spcharms/service_hook.py
+++ b/lib/spcharms/service_hook.py
@@ -4,9 +4,6 @@ the same charm so that the state may be reported to other charms.
 """
 import json
 
-from charms import reactive
-from charms.reactive import helpers
-
 from charmhelpers.core import hookenv, unitdata
 
 from spcharms import kvdata
@@ -16,7 +13,7 @@ def init_state():
     """
     Initialize the local state as an empty dictionary.
     """
-    return {'-local': {}}
+    return {}
 
 
 def get_state(db=None):
@@ -58,80 +55,150 @@ def update_state(db, state, changed, key, name, value):
     return changed
 
 
-def add_present_node(name, value, rel_name, rdebug=lambda s: s):
+def add_present_node(service, name, value, rdebug=lambda s: s):
     """
-    Update a peer's state and send the full structure right back if needed.
+    Update a peer's state.
     """
     db = unitdata.kv()
     (state, changed) = get_state(db)
-    changed = update_state(db, state, changed, '-local', name, value)
-    if changed:
-        rdebug('hm, let us then try to fetch the relation ids for {rel_name}'
-               .format(rel_name=rel_name))
-        rel_ids = hookenv.relation_ids(rel_name)
-        rdebug('rel_ids: {rel_ids}'.format(rel_ids=rel_ids))
-        for rel_id in rel_ids:
-            rdebug('- trying for {rel_id}'.format(rel_id=rel_id))
-            hookenv.relation_set(rel_id,
-                                 storpool_service=json.dumps(state['-local']))
-            rdebug('  - looks like we managed it for {rel_id}'
-                   .format(rel_id=rel_id))
-        rdebug('that is it for the rel_ids')
+    return update_state(db, state, changed, service, name, value)
 
 
-def get_present_nodes():
+def get_present_nodes(service):
     """
     Fetch the current state of the charm's units.
     """
     (state, _) = get_state()
-    res = {}
-    for arr in state.values():
-        for (key, value) in arr.items():
-            res[key] = value or res.get(key, False)
-    return res
+    return state.get(service, {})
 
 
-def handle(hk, attaching, data, rdebug=lambda s: s):
+def handle(data, rdebug=lambda s: s):
     """
     Handle a state change of the internal hook; update our state if needed.
     """
-    rdebug('service_hook.handle for a {t} hook {name}, attaching {attaching}, '
-           'data keys {ks}'
-           .format(t=type(hk).__name__,
-                   name=hk.relation_name,
-                   attaching=attaching,
-                   ks=sorted(data.keys()) if data is not None else None))
+    rdebug('service_hook.handle {ks}'.format(ks=sorted(data.keys())))
     db = unitdata.kv()
     (state, changed) = get_state(db)
     rdebug('- current state: {state}'.format(state=state))
     rdebug('- changed even at the start: {changed}'.format(changed=changed))
 
-    key = hk.conversation().key
-    rdebug('- conversation key: {key}'.format(key=key))
-    if attaching:
-        rdebug('- attaching: adding new hosts as reported')
-        for (name, value) in data.items():
-            rdebug('  - processing name "{name}" value "{value}"'
-                   .format(name=name, value=value))
-            if update_state(db, state, changed, key, name, value):
+    # TODO: handle detaching in an entirely different way
+    for (svc, sdata) in data.items():
+        for (name, value) in sdata.items():
+            if update_state(db, state, changed, svc, name, value):
+                rdebug('- changed: service "{svc}" name "{name}" '
+                       'value "{value}"'
+                       .format(svc=svc, name=name, value=value))
                 changed = True
-            rdebug('    - changed: {changed}'.format(changed=changed))
-    else:
-        if key in state:
-            rdebug('- detaching: the conversation has been recorded, '
-                   'removing it')
-            del state[key]
-            changed = True
-            set_state(db, state)
-        else:
-            rdebug('- detaching, but we had no idea we were having '
-                   'this conversation, so nah')
 
     if changed:
         rdebug('- updated state: {state}'.format(state=state))
-
-    if changed or helpers.data_changed(kvdata.KEY_PRESENCE, state) or \
-       not helpers.is_state('storpool-service.changed'):
-        rdebug('- something changed, notifying whomever should care')
-        reactive.set_state('storpool-service.change')
     return changed
+
+
+def get_remote_presence():
+    """
+    Get the presence data sent down a storpool-service/presence interface.
+    """
+    conf = unitdata.kv().get(kvdata.KEY_REMOTE_PRESENCE)
+    presence = conf.get('presence')
+    if presence is None:
+        return None
+    elif presence.get('version') != '1.0':
+        raise Exception('Internal error: presence data with weird version')
+    elif 'data' not in presence:
+        raise Exception('Internal error: presence data with no, uhm, data')
+    return presence['data']
+
+
+def import_presence(presence):
+    """
+    Parse the presence data sent down a storpool-service/presence interface.
+    """
+    if 'version' not in presence:
+        raise Exception('Internal error: presence data with no version')
+    elif not presence['version'].startswith('1.'):
+        raise Exception('Internal error: presence data with weird version')
+    elif 'data' not in presence:
+        raise Exception('Internal error: presence data with no, mm, data')
+
+    # Future version checks and reformatting go here
+    return {
+        **presence,
+        'version': '1.0',
+    }
+
+
+def handle_remote_presence(hk, rdebug=lambda s: s):
+    hk.set_state('{relation_name}.notify')
+    conv = hk.conversation()
+    spconf = conv.get_remote('storpool_presence')
+    if spconf is None:
+        rdebug('no presence data yet')
+        return
+
+    oldconf = unitdata.kv().get(kvdata.KEY_REMOTE_PRESENCE_STR)
+    if spconf == oldconf:
+        rdebug('nothing changed')
+        return
+
+    rdebug('whee, we got something new from the {key} conversation, '
+           'trying to deserialize it'.format(key=conv.key))
+    try:
+        conf = json.loads(spconf)
+        rdebug('got something: type {t}, dict keys: {k}'
+               .format(t=type(conf).__name__,
+                       k=sorted(conf.keys()) if isinstance(conf, dict)
+                       else []))
+        if not isinstance(conf, dict):
+            rdebug('well, it is not a dictionary, is it?')
+            return
+        presence = conf.get('presence', None)
+        if not isinstance(presence, dict):
+            rdebug('no presence data, just {keys}'
+                   .format(keys=','.join(sorted(conf.keys()))))
+            return
+        presence_version = presence.get('version')
+        if presence_version is None:
+            rdebug('no presence data version, ignoring')
+            return
+        elif not presence_version.startswith('1.'):
+            rdebug('unsupported presence data version {ver}, ignoring'
+                   .format(ver=presence_version))
+            return
+        elif 'data' not in presence:
+            rdebug('invalid presence data format: no "data" member')
+            return
+        rdebug('configured services: {svcs}'
+               .format(svcs=','.join(sorted(presence.keys()))))
+        rdebug('configured block nodes: {nodes}'
+               .format(nodes=','
+                       .join(sorted(presence.get('block',
+                                                 {}).keys()))))
+
+        unitdata.kv().set(kvdata.KEY_REMOTE_PRESENCE_STR, spconf)
+        conf['presence'] = import_presence(conf['presence'])
+        unitdata.kv().set(kvdata.KEY_REMOTE_PRESENCE, conf)
+        hk.set_state('{relation_name}.changed')
+
+    except Exception as e:
+        rdebug('oof, could not parse the presence data passed down '
+               'the hook: {e}'.format(e=e))
+
+
+def send_presence_data(rel_name, ext_data={}, rdebug=lambda s: s):
+    rdebug('sending presence data along the {name} hook'.format(name=rel_name))
+    data = json.dumps({
+        **ext_data,
+        'presence': {
+            'version': '1.0',
+            'data': dict(get_state()[0]),
+        },
+    })
+    rel_ids = hookenv.relation_ids(rel_name)
+    rdebug('- got rel_ids {rel_ids}'.format(rel_ids=rel_ids))
+    for rel_id in rel_ids:
+        rdebug('  - trying for {rel_id}'.format(rel_id=rel_id))
+        hookenv.relation_set(rel_id, storpool_presence=data)
+        rdebug('  - done with {rel_id}'.format(rel_id=rel_ids))
+    rdebug('- done with the rel_ids')

--- a/lib/spcharms/service_hook.py
+++ b/lib/spcharms/service_hook.py
@@ -6,6 +6,7 @@ import json
 
 from charmhelpers.core import hookenv, unitdata
 
+from spcharms import config as spconfig
 from spcharms import kvdata
 
 
@@ -111,6 +112,14 @@ def get_remote_presence():
     return presence['data']
 
 
+def get_remote_config():
+    """
+    Get the configuration sent down a storpool-service/presence interface.
+    """
+    conf = unitdata.kv().get(kvdata.KEY_REMOTE_PRESENCE)
+    return conf.get('config')
+
+
 def import_presence(presence):
     """
     Parse the presence data sent down a storpool-service/presence interface.
@@ -188,11 +197,19 @@ def handle_remote_presence(hk, rdebug=lambda s: s):
 
 def send_presence_data(rel_name, ext_data={}, rdebug=lambda s: s):
     rdebug('sending presence data along the {name} hook'.format(name=rel_name))
+    cfg = spconfig.m()
     data = json.dumps({
         **ext_data,
         'presence': {
             'version': '1.0',
             'data': dict(get_state()[0]),
+        },
+        'config': {
+            'storpool_repo_url': cfg.get('storpool_repo_url'),
+            'storpool_version': cfg.get('storpool_version'),
+            'storpool_openstack_version':
+                cfg.get('storpool_openstack_version'),
+            'storpool_conf': cfg.get('storpool_conf'),
         },
     })
     rel_ids = hookenv.relation_ids(rel_name)

--- a/unit_tests/test_service.py
+++ b/unit_tests/test_service.py
@@ -116,7 +116,6 @@ from spcharms import service_hook as testee
 SP_NODE = '42'
 
 STATE_NONE = {
-    '-local': {},
 }
 
 
@@ -153,15 +152,15 @@ class TestStorPoolService(unittest.TestCase):
         e_kv = MockDB()
 
         (state_r, ch_t) = testee.get_state()
-        self.assertEqual(set(state_r['-local'].keys()), set())
+        self.assertEqual(set(state_r.keys()), set())
         self.assertTrue(ch_t)
 
         (state_b, ch_t) = testee.get_state(b_kv)
-        self.assertEqual(set(state_b['-local'].keys()), set())
+        self.assertEqual(set(state_b.keys()), set())
         self.assertTrue(ch_t)
 
         (state_e, ch_t) = testee.get_state(e_kv)
-        self.assertEqual(list(state_e['-local'].keys()), [])
+        self.assertEqual(list(state_e.keys()), [])
         self.assertTrue(ch_t)
 
         r_kv.set(kvdata.KEY_PRESENCE, state_b)
@@ -261,18 +260,18 @@ class TestStorPoolService(unittest.TestCase):
         # Start with an empty database, this is supposed to fill out
         # the information about our node, too.
         node_name = 'new-node'
-        testee.add_present_node(node_name, '13', 'peer-relation')
+        testee.add_present_node('here', node_name, '13', 'peer-relation')
 
         # Now let's see if it has filled in the database...
         self.assertEqual({
             kvdata.KEY_PRESENCE: {
-                '-local': {
+                'here': {
                     node_name: '13',
                 },
             },
         }, r_kv.r_get_all())
 
-        jdata = json.dumps(r_kv.get(kvdata.KEY_PRESENCE)['-local'])
+        jdata = json.dumps(r_kv.get(kvdata.KEY_PRESENCE))
         self.assertEqual(rel_data_received,
                          list(map(lambda rid: [rid, jdata], rels)))
 
@@ -284,16 +283,18 @@ class TestStorPoolService(unittest.TestCase):
         # OK, let's see what happens if another node comes up
         rel_data_received = []
         another_name = 'newer-node'
-        testee.add_present_node(another_name, '32', 'peer-relation')
+        testee.add_present_node('there', another_name, '32', 'peer-relation')
         self.assertEqual({
             kvdata.KEY_PRESENCE: {
-                '-local': {
+                'here': {
                     node_name: '13',
+                },
+                'there': {
                     another_name: '32',
                 },
             },
         }, r_kv.r_get_all())
 
-        jdata = json.dumps(r_kv.get(kvdata.KEY_PRESENCE)['-local'])
+        jdata = json.dumps(r_kv.get(kvdata.KEY_PRESENCE))
         self.assertEqual(rel_data_received,
                          list(map(lambda rid: [rid, jdata], rels)))


### PR DESCRIPTION
Rework the way the StorPool charms (cinder-storpool and storpool-block) notify their own peers and the other charm about the readiness of the units on specific machines and with specific StorPool IDs.